### PR TITLE
feat: implement task 38_add display name

### DIFF
--- a/components/messages/messagesChat.vue
+++ b/components/messages/messagesChat.vue
@@ -36,7 +36,11 @@
           <v-list-item-content class="py-2">
             <v-list-item-title>
               <span style="font-weight: bold; font-size: 19px">
-                {{ chatPartnerUserName }}
+                {{
+                  getProfile(chatPartnerUserName).displayName.length > 0
+                    ? getProfile(chatPartnerUserName).displayName
+                    : chatPartnerUserName
+                }}
               </span>
             </v-list-item-title>
             <v-list-item-subtitle
@@ -259,6 +263,7 @@ export default {
   },
   destroyed() {
     this.exitfetchReactions = false
+    console.log('cp destroyed', this.chatPartnerUserName)
   },
   methods: {
     ...mapActions([
@@ -269,17 +274,11 @@ export default {
       'encryptReaction',
     ]),
     async loopFetchReactions() {
-      console.log(
-        'cp',
-        this.chatPartnerUserName,
-        this.getDirectMessages(this.chatPartnerUserId).length
-      )
       // stop loop if user navigates to a different chatuser conversation or page
       if (this.exitfetchReactions === false) {
         return
       }
       if (this.getDirectMessages(this.chatPartnerUserId).length > 0) {
-        console.log('cploop')
         for (
           let idx = 0;
           idx < this.getDirectMessages(this.chatPartnerUserId).length;

--- a/components/messages/messagesContactlist.vue
+++ b/components/messages/messagesContactlist.vue
@@ -80,7 +80,12 @@
           >
             <v-list-item-title>
               <span style="font-weight: bold" class="truncate">
-                {{ chatPartnerUserName(entry[1]) }}
+                {{
+                  getProfile(chatPartnerUserName(entry[1])).displayName.length >
+                  0
+                    ? getProfile(chatPartnerUserName(entry[1])).displayName
+                    : chatPartnerUserName(entry[1])
+                }}
               </span>
               <span class="truncate" style="color: #787878">
                 @{{ chatPartnerUserName(entry[1]) }}

--- a/components/notifications/Jam.vue
+++ b/components/notifications/Jam.vue
@@ -7,7 +7,6 @@
     style="background-color: inherit !important"
     @click="goTo(toThreadLink, $event)"
   >
-    <!-- {{ jam }} -->
     <v-row no-gutters>
       <v-col
         style="max-width: 50px; max-height=88px; margin-top: -2px;"
@@ -23,8 +22,6 @@
         ></nuxt-link>
       </v-col>
       <v-col>
-        <!-- {{ $route.params.username }} -->
-        <!-- need name and avatar correlated to jam that was liked - from dash platform -->
         <nuxt-link :to="'/' + jam.userName">
           <v-avatar color="lightgray" size="30">
             <v-img
@@ -32,9 +29,8 @@
               :src="getProfile(jam.userName).avatar"
             ></v-img> </v-avatar
         ></nuxt-link>
-        <!-- <v-btn icon><v-icon large color="brown">mdi-dog</v-icon></v-btn> -->
         <div>
-          <span style="font-weight: bold">{{ jam.userName }} </span>rejammed
+          <span style="font-weight: bold"> @{{ jam.userName }} </span>rejammed
           your Jam
         </div>
         <!-- <span v-linkify="linkifyMe(opText)" /> -->
@@ -45,7 +41,6 @@
           type="list-item-two-line"
         ></v-skeleton-loader>
         <!-- displayJamText(notification.id).text -->
-        <!-- need jam.text from correlated jam - pull from dash platform -->
       </v-col>
     </v-row>
   </v-card>

--- a/components/notifications/Like.vue
+++ b/components/notifications/Like.vue
@@ -17,8 +17,6 @@
         </v-btn></v-col
       >
       <v-col>
-        <!-- {{ $route.params.username }} -->
-        <!-- need name and avatar correlated to jam that was liked - from dash platform -->
         <nuxt-link :to="'/' + like.userName">
           <v-avatar color="lightgray" size="30">
             <v-img
@@ -26,10 +24,9 @@
               :src="getProfile(like.userName).avatar"
             ></v-img> </v-avatar
         ></nuxt-link>
-        <!-- <v-btn icon><v-icon large color="brown">mdi-dog</v-icon></v-btn> -->
         <div>
-          <span style="font-weight: bold">{{ like.userName }} </span>liked your
-          Jam
+          <span style="font-weight: bold"> @{{ like.userName }} </span>liked
+          your Jam
         </div>
         <span v-html="linkifyMe(opText)" />
         <v-skeleton-loader

--- a/components/profile/onboarding/DisplayName.vue
+++ b/components/profile/onboarding/DisplayName.vue
@@ -1,0 +1,93 @@
+<template>
+  <div>
+    <v-textarea
+      v-model="newDisplayName"
+      label="Display Name"
+      rows="1"
+      counter="20"
+      :rules="rules"
+    >
+    </v-textarea>
+    <v-card-actions>
+      <v-spacer />
+      <v-btn
+        v-if="newDisplayName != profile.displayName"
+        style="color: white"
+        :loading="isSaving"
+        :disabled="!isRuleValid"
+        rounded
+        color="#008de4"
+        @click="saveDisplayName"
+        >Save</v-btn
+      >
+      <v-spacer />
+    </v-card-actions>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex'
+// import crypto from '@dashevo/dashcore-lib'
+
+export default {
+  name: 'DisplayName',
+  data() {
+    return {
+      profile: {},
+      isSaving: false,
+      newDisplayName: '',
+      rules: [
+        (value) => (value || '').length <= 20 || 'Max 20 characters',
+        (value) => {
+          const pattern = /^$|^[1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz -]+$/
+          return (
+            pattern.test(value) ||
+            'Name can consist of A-Z,  0-9 and - within the name'
+          )
+        },
+      ],
+    }
+  },
+  computed: {
+    ...mapGetters(['getProfile']),
+    isRuleValid() {
+      const rulesResults = this.rules.map((fxn) => fxn(this.newDisplayName))
+      return rulesResults.every((value) => value === true)
+    },
+  },
+  created() {
+    this.profile = this.getProfile(this.$store.state.name.label)
+    this.newDisplayName = this.profile.displayName
+  },
+  methods: {
+    ...mapActions(['submitDocument', 'fetchProfile', 'saveToDatastore']),
+    async saveDisplayName() {
+      this.isSaving = true
+      console.log('this.profile :>> ', this.profile)
+      const { avatarRaw, themeRaw } = this.profile
+      console.log('avatarRaw :>> ', avatarRaw)
+      console.log('themeRaw :>> ', themeRaw)
+      console.log('displayname :>> ', this.newDisplayName)
+      const doc = {
+        displayName: this.newDisplayName,
+        statusMessage: this.newStatusMessage,
+        avatar: avatarRaw,
+        theme: themeRaw,
+        userId: this.$store.state.name.userId,
+        userNormalizedLabel: this.$store.state.name.label.toLowerCase(),
+      }
+      console.log('doc :>> ', doc)
+
+      await this.submitDocument({ contract: 'jembe', type: 'profile', doc })
+
+      await this.fetchProfile(this.$store.state.name.label)
+
+      this.isSaving = false
+
+      this.$emit('nextStep')
+    },
+  },
+}
+</script>
+
+<style></style>

--- a/components/profile/onboarding/OnboardDialog.vue
+++ b/components/profile/onboarding/OnboardDialog.vue
@@ -51,9 +51,10 @@
         </v-card-title>
         <v-card-subtitle class="pt-4" v-text="steps[step].subtitle" />
         <v-card-text class="text-center mt-14">
-          <AvatarPicker v-if="step === 0" @nextStep="step += 1" />
-          <ThemePicker v-if="step === 1" @nextStep="step += 1" />
-          <BioForm v-if="step === 2" @nextStep="$emit('close')" />
+          <DisplayName v-if="step === 0" @nextStep="step += 1" />
+          <AvatarPicker v-if="step === 1" @nextStep="step += 1" />
+          <ThemePicker v-if="step === 2" @nextStep="step += 1" />
+          <BioForm v-if="step === 3" @nextStep="$emit('close')" />
         </v-card-text>
         <!-- <ComposeJam :reply-to-jam-id="replyToJamId" @success="close()" /> -->
       </v-card>
@@ -65,10 +66,11 @@
 import AvatarPicker from '~/components/profile/onboarding/AvatarPicker'
 import ThemePicker from '~/components/profile/onboarding/ThemePicker'
 import BioForm from '~/components/profile/onboarding/BioForm'
+import DisplayName from '~/components/profile/onboarding/DisplayName'
 
 export default {
   name: 'OnboardDialog',
-  components: { AvatarPicker, ThemePicker, BioForm },
+  components: { AvatarPicker, ThemePicker, BioForm, DisplayName },
   props: {
     dialog: { type: Boolean, default: false },
     // replyToJamId: String,
@@ -79,6 +81,11 @@ export default {
     return {
       step: 0,
       steps: [
+        {
+          title: 'Choose your Jembe display name',
+          subtitle:
+            'Choose the name you want to display along with your username',
+        },
         {
           title: 'Pick a profile picture',
           subtitle:

--- a/components/tweet.vue
+++ b/components/tweet.vue
@@ -53,7 +53,13 @@
           >
             <span>
               <nuxt-link :to="'/' + jam.userName" class="jam-name"
-                ><span id="username" class="username"> {{ jam.userName }}</span>
+                ><span id="username" class="username">
+                  {{
+                    getProfile(jam.userName).displayName
+                      ? getProfile(jam.userName).displayName
+                      : jam.userName
+                  }}</span
+                >
                 <span class="handle"> @{{ jam.userName }} · </span>
               </nuxt-link>
               <span class="time-posted"

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -366,6 +366,12 @@ export default {
   font-weight: bold;
   font-family: 'Montserrat';
 }
+.font-username {
+  color: rgba(20, 23, 26, 0.8) !important;
+  font-size: 16px;
+  font-weight: 500px;
+  font-family: 'Montserrat';
+}
 .menu-text {
   color: rgba(20, 23, 26, 0.8) !important;
 }

--- a/pages/_profile/index.vue
+++ b/pages/_profile/index.vue
@@ -18,7 +18,14 @@
               @click="$router.push({ path: '../discover' })"
               ><v-icon>mdi-arrow-left</v-icon></v-btn
             >
-            <span class="font-header pl-3"> {{ jamUser }} </span>
+            <span class="font-header pl-3">
+              {{
+                getProfile(jamUser).displayName
+                  ? getProfile(jamUser).displayName
+                  : jamUser
+              }}
+            </span>
+            <span class="font-username pl-3"> @{{ jamUser }} </span>
           </v-row>
           <v-card flat tile class="my-2">
             <!-- <v-img :src="require('~/assets/avataaar.png')" height="194"></v-img> -->
@@ -31,10 +38,18 @@
               <v-img :src="getProfile(jamUser).avatar" alt="" />
             </v-avatar>
             <v-list-item>
-              <v-list-item-content>
-                <v-list-item-title class="headline"
-                  >{{ jamUser
-                  }}<v-btn
+              <v-list-item-content class="py-0">
+                <v-list-item-title>
+                  <span class="font-header">
+                    {{
+                      getProfile(jamUser).displayName
+                        ? getProfile(jamUser).displayName
+                        : jamUser
+                    }}
+                  </span>
+                  <br />
+                  <span class="font-username">@{{ jamUser }}</span>
+                  <v-btn
                     v-if="
                       jamUser.toLowerCase() ===
                       $store.state.name.label.toLowerCase()
@@ -60,7 +75,7 @@
                     dense
                     outlined
                     rounded
-                    class="mt-n3 lowercase"
+                    class="mt-n5 lowercase"
                     font-weight="bold"
                     style="color: #008de4"
                     :disabled="!$store.getters.hasSession"

--- a/schema/JEMBE_CONTRACT.json
+++ b/schema/JEMBE_CONTRACT.json
@@ -309,9 +309,16 @@
             "userNormalizedLabel": "asc"
           }
         ]
+      },
+      {
+        "properties": [
+          {
+            "displayName": "asc"
+          }
+        ]
       }
     ],
-    "required": ["userNormalizedLabel", "userId", "$updatedAt", "$createdAt"],
+    "required": ["userNormalizedLabel", "userId", "$updatedAt", "$createdAt", "displayName"],
     "properties": {
       "theme": {
         "type": "string"
@@ -331,6 +338,12 @@
       "userNormalizedLabel": {
         "type": "string",
         "maxLength": 1024,
+        "minLength": 0
+      },
+      "displayName": {
+        "type": "string",
+        "pattern": "^$|^[1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz ]+$",
+        "maxLength": 20,
         "minLength": 0
       }
     },

--- a/store/index.js
+++ b/store/index.js
@@ -308,6 +308,7 @@ export const getters = {
     profile.avatar = storedProfile.avatar || require('~/assets/avataaar.png')
     profile.theme = storedProfile.theme || require('~/assets/theme.png')
     profile.statusMessage = storedProfile.statusMessage || ''
+    profile.displayName = storedProfile.displayName || ''
 
     profile.avatarRaw = storedProfile.avatarRaw || ''
     profile.themeRaw = storedProfile.themeRaw || ''


### PR DESCRIPTION
Add display usernames separate from unchangeable Dash identity: 
+ save custom usernames in profile docType within Jembe DashPlatform contract
+ UI to modify username on Jembe under "setup profile" tab
+ create rules for enabling display names that are less than or equal to 20 characters and consist only of A-Z, 0-9, whitespaces and dash (-); disable save to profile docType if rule is not satisfied. Enable a display name to be erased (replaced with nothing)
+ display display name when one exists, display username in place of display name when one does not exist