### PR TITLE
fix: messages overlay shows displayname

### DIFF
--- a/components/messages/messagesOverlay.vue
+++ b/components/messages/messagesOverlay.vue
@@ -20,7 +20,11 @@
               <v-list-item-content class="py-2 pl-3">
                 <v-list-item-title>
                   <span style="font-weight: bold; font-size: 19px">
-                    {{ chatPartnerUserName }}
+                    {{
+                      getProfile(chatPartnerUserName).displayName.length > 0
+                        ? getProfile(chatPartnerUserName).displayName
+                        : chatPartnerUserName
+                    }}
                   </span>
                 </v-list-item-title>
                 <v-list-item-subtitle


### PR DESCRIPTION
fix: show display name when one exists in the header of the messages chat overlay on the discover page